### PR TITLE
TRESTLE-718: Add contributes_to relationship.

### DIFF
--- a/trestle-annotations/src/main/java/com/nickrobison/trestle/reasoner/annotations/Related.java
+++ b/trestle-annotations/src/main/java/com/nickrobison/trestle/reasoner/annotations/Related.java
@@ -1,0 +1,14 @@
+package com.nickrobison.trestle.reasoner.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by nickrobison on 3/10/20
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Related {
+}

--- a/trestle-ontology-testing/src/main/java/com/nickrobison/trestle/testing/OntologyTest.java
+++ b/trestle-ontology-testing/src/main/java/com/nickrobison/trestle/testing/OntologyTest.java
@@ -201,11 +201,11 @@ public abstract class OntologyTest {
 
 //        Check to ensure the relation is inferred
         final TrestleTransaction trestleTransaction = this.ontology.createandOpenNewTransaction(false);
-        final OWLNamedIndividual test_maputo = df.getOWLNamedIndividual(IRI.create("trestle:", "maputo:2013:3000"));
+        final OWLNamedIndividual testMaputo = df.getOWLNamedIndividual(IRI.create("trestle:", "maputo:2013:3000"));
         final OWLObjectProperty owlObjectProperty = df.getOWLObjectProperty(StaticIRI.hasFactIRI);
-        final Optional<List<OWLObjectPropertyAssertionAxiom>> individualObjectProperty = ontology.getIndividualObjectProperty(test_maputo, owlObjectProperty);
-        Assertions.assertTrue(individualObjectProperty.isPresent(), "Should have related facts");
-        Assertions.assertEquals(4, individualObjectProperty.get().size(), "Wrong number of facts");
+        final Optional<List<OWLObjectPropertyAssertionAxiom>> individualObjectProperty = ontology.getIndividualObjectProperty(testMaputo, owlObjectProperty);
+        assertAll(() -> assertTrue(individualObjectProperty.isPresent(), "Should have related facts"),
+                () -> assertEquals(4, individualObjectProperty.get().size(), "Wrong number of facts"));
 
 //        Now for the sparql query
         String queryString = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +

--- a/trestle-ontology-testing/src/main/java/com/nickrobison/trestle/testing/OntologyTest.java
+++ b/trestle-ontology-testing/src/main/java/com/nickrobison/trestle/testing/OntologyTest.java
@@ -205,7 +205,7 @@ public abstract class OntologyTest {
         final OWLObjectProperty owlObjectProperty = df.getOWLObjectProperty(StaticIRI.hasFactIRI);
         final Optional<List<OWLObjectPropertyAssertionAxiom>> individualObjectProperty = ontology.getIndividualObjectProperty(testMaputo, owlObjectProperty);
         assertAll(() -> assertTrue(individualObjectProperty.isPresent(), "Should have related facts"),
-                () -> assertEquals(4, individualObjectProperty.get().size(), "Wrong number of facts"));
+                () -> assertEquals(6, individualObjectProperty.get().size(), "Wrong number of facts"));
 
 //        Now for the sparql query
         String queryString = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
@@ -217,7 +217,7 @@ public abstract class OntologyTest {
                 "FILTER(!isURI(?object) && !isBlank(?object) && ?object = 41374) }";
 
         final TrestleResultSet resultSet = ontology.executeSPARQLResults(queryString);
-        Assertions.assertEquals(1, resultSet.getResults().size(), "Wrong number of relations");
+        Assertions.assertEquals(2, resultSet.getResults().size(), "Wrong number of relations");
 
 //        Test for spatial/temporal object relations and that they're inferred correctly.
         queryString = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +

--- a/trestle-querybuilder/src/main/java/com/nickrobison/trestle/querybuilder/QueryBuilder.java
+++ b/trestle-querybuilder/src/main/java/com/nickrobison/trestle/querybuilder/QueryBuilder.java
@@ -321,6 +321,25 @@ public class QueryBuilder {
         return stringValue;
     }
 
+    public String buildContributesToQuery(OWLNamedIndividual individual, OWLDataPropertyAssertionAxiom dataProperty) {
+        final ParameterizedSparqlString ps = buildBaseString();
+
+        ps.setCommandText(String.format("INSERT { " +
+                        "<%s> trestle:contributes_to ?individual } " +
+                        "WHERE { " +
+                        "?individual trestle:has_fact ?f . " +
+//                        "MINUS {?individual rdf:type <%s>} . " +
+                        "?f <%s> %s }",
+                this.getFullIRIString(individual),
+                this.getFullIRIString(dataProperty.getProperty().asOWLDataProperty()),
+                // This should probably be replaced with an actual literal node
+                dataProperty.getObject().toString()));
+
+        final String stringValue = ps.toString();
+        logger.trace(stringValue);
+        return stringValue;
+    }
+
     /**
      * Retrieve all Fact values for a given individual
      * If a temporal range is provided, the returned values will be valid within that range

--- a/trestle-reasoner/pom.xml
+++ b/trestle-reasoner/pom.xml
@@ -174,6 +174,11 @@
             <artifactId>clj-fuzzy</artifactId>
             <version>0.4.1</version>
         </dependency>
+        <dependency>
+            <groupId>else-let</groupId>
+            <artifactId>else-let</artifactId>
+            <version>0.1.0</version>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.clojure</groupId>

--- a/trestle-reasoner/pom.xml
+++ b/trestle-reasoner/pom.xml
@@ -174,13 +174,13 @@
             <artifactId>clj-fuzzy</artifactId>
             <version>0.4.1</version>
         </dependency>
+        <!--Test Dependencies-->
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>tools.nrepl</artifactId>
             <version>0.2.13</version>
             <scope>test</scope>
         </dependency>
-        <!--Test Dependencies-->
     </dependencies>
     <build>
         <testResources>

--- a/trestle-reasoner/src/main/clojure/com/nickrobison/trestle/reasoner/parser/parser.clj
+++ b/trestle-reasoner/src/main/clojure/com/nickrobison/trestle/reasoner/parser/parser.clj
@@ -13,6 +13,7 @@
             [clojure.core.reducers :as r]
             [clojure.tools.logging :as log]
             [clojure.set :as set]
+            [else-let.core :refer :all]
             [com.nickrobison.trestle.reasoner.parser.utils.predicates :as pred]
             [com.nickrobison.trestle.reasoner.parser.utils.members :as m]
     ; We have to require the methods we're extending, as well as namespaces where we did the extension
@@ -498,13 +499,14 @@
 
   (isFactRelated [this clazz factName]
     (let [parsedClass (.getRegisteredClass this clazz)]
-      (m/filter-and-get
-        (:members parsedClass)
-        (fn [member]
-          (m/filter-member-name-iri
-            factName
-            member))
-        :related)))
+      (else-let [related (m/filter-and-get
+                      (:members parsedClass)
+                      (fn [member]
+                        (m/filter-member-name-iri
+                          factName
+                          member))
+                      :related) false]
+                related)))
 
   (getClassProjection ^Long [this clazz]
     (let [parsedClass (.getRegisteredClass this clazz)]

--- a/trestle-reasoner/src/main/clojure/com/nickrobison/trestle/reasoner/parser/utils/members.clj
+++ b/trestle-reasoner/src/main/clojure/com/nickrobison/trestle/reasoner/parser/utils/members.clj
@@ -27,6 +27,13 @@
        (map #(get % key))
        first))
 
+(defn member-field-get [parsedClass fn field]
+  "Filter members by the given [factName] and extract the provided [field] from the map"
+  (filter-and-get
+    (:members parsedClass)
+    fn
+    field))
+
 (declare filter-java-member-name)
 (defn ^IRI build-iri
   "Build the property IRI for the Member"

--- a/trestle-reasoner/src/main/clojure/com/nickrobison/trestle/reasoner/parser/utils/predicates.clj
+++ b/trestle-reasoner/src/main/clojure/com/nickrobison/trestle/reasoner/parser/utils/predicates.clj
@@ -1,6 +1,6 @@
 (ns com.nickrobison.trestle.reasoner.parser.utils.predicates
   (:import (java.lang.reflect Modifier Method Field Constructor)
-           (com.nickrobison.trestle.reasoner.annotations Ignore Fact Spatial Language NoMultiLanguage IndividualIdentifier TrestleCreator)
+           (com.nickrobison.trestle.reasoner.annotations Ignore Fact Spatial Language NoMultiLanguage IndividualIdentifier TrestleCreator Related)
            (com.nickrobison.trestle.reasoner.annotations.temporal DefaultTemporal StartTemporal EndTemporal)
            (com.nickrobison.trestle.types TemporalType))
   (:require [clojure.string :as string]
@@ -82,6 +82,7 @@
              (= (get-member-name entity) "notify")
              (= (get-member-name entity) "notifyAll")
              (= (get-member-name entity) "getClass")))
+(defn related? [entity] (hasAnnotation? entity Related))
 (defn void-return? [entity] (= (.getReturnType entity) Void))
 (defn string-return? [entity] (= (get-member-return-type entity) String))
 (defn include? [entity] ((some-fn fact?
@@ -89,6 +90,7 @@
                                   identifier?
                                   language?
                                   temporal?
+                                  related?
                                   noMultiLanguage?
                                   noAnnotations?) entity))
 
@@ -97,7 +99,7 @@
   ((every-pred
      ignore?
      (or spatial? identifier?))
-    entity))
+   entity))
 
 (defn member-type [member defaultLanguageCode]
   (let [

--- a/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/engines/object/TrestleObjectReader.java
+++ b/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/engines/object/TrestleObjectReader.java
@@ -51,6 +51,7 @@ import static com.nickrobison.trestle.reasoner.parser.TemporalParser.parseTempor
 /**
  * Created by nickrobison on 2/13/18.
  */
+@SuppressWarnings("TypeParameterExplicitlyExtendsObject")
 public class TrestleObjectReader implements ITrestleObjectReader {
 
     private static final Logger logger = LoggerFactory.getLogger(TrestleObjectReader.class);
@@ -112,7 +113,7 @@ public class TrestleObjectReader implements ITrestleObjectReader {
     }
 
     @Override
-    public <T extends @NonNull Object> T readTrestleObject(Class<T> clazz, String objectID, @Nullable Temporal validTemporal, @Nullable Temporal databaseTemporal) throws TrestleClassException, MissingOntologyEntity {
+    public <T extends @NonNull Object> T readTrestleObject(Class<T> clazz, String objectID, @Nullable Temporal validTemporal, @Nullable Temporal databaseTemporal) {
         final IRI individualIRI = parseStringToIRI(this.reasonerPrefix, objectID);
         return readTrestleObject(clazz, individualIRI, false, validTemporal, databaseTemporal);
     }
@@ -223,7 +224,7 @@ public class TrestleObjectReader implements ITrestleObjectReader {
         if (dataProperties.isPresent()) {
             try {
 //            Facts
-                final CompletableFuture<List<TrestleFact>> factsFuture = CompletableFuture.supplyAsync(() -> {
+                final CompletableFuture<List<TrestleFact<?>>> factsFuture = CompletableFuture.supplyAsync(() -> {
                     final Instant individualRetrievalStart = Instant.now();
                     final TrestleTransaction tt = ontology.createandOpenNewTransaction(trestleTransaction);
                     TrestleResultSet resultSet = ontology.executeSPARQLResults(factQuery);
@@ -248,7 +249,6 @@ public class TrestleObjectReader implements ITrestleObjectReader {
                                         final Optional<TemporalObject> factValidTemporal = TemporalObjectBuilder.buildTemporalFromResults(TemporalScope.VALID, result.getLiteral("va"), result.getLiteral("vf"), result.getLiteral("vt"));
 //                                    Get database temporal
                                         final Optional<TemporalObject> factDatabaseTemporal = TemporalObjectBuilder.buildTemporalFromResults(TemporalScope.DATABASE, Optional.empty(), result.getLiteral("df"), result.getLiteral("dt"));
-                                        //noinspection unchecked
                                         return this.factFactory.createFact(
                                                 clazz,
                                                 assertion,
@@ -340,6 +340,7 @@ public class TrestleObjectReader implements ITrestleObjectReader {
                             .min(TemporalUtils::compareTemporals)
                             .map(Temporal.class::cast);
 
+                    //noinspection OptionalGetWithoutIsPresent // I think it's fine to throw an exception here, if we end up in a bad state
                     return new TrestleObjectState(constructorArguments, validStart.get(), validEnd.get(), dbStart.get(), dbEnd.get());
                 }, this.objectReaderThreadPool);
                 final TrestleObjectState objectState = argumentsFuture.get();
@@ -444,8 +445,8 @@ public class TrestleObjectReader implements ITrestleObjectReader {
                 .thenApply(results -> results
                         .getResults()
                         .stream()
-                        .map((result) -> result.unwrapLiteral("o"))
-                        .map((literal) -> this.handleLiteral(clazz, datatype, literal))
+                        .map(result -> result.unwrapLiteral("o"))
+                        .map(literal -> this.handleLiteral(clazz, datatype, literal))
                         .collect(Collectors.toList()));
 
         try {

--- a/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/engines/object/TrestleObjectWriter.java
+++ b/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/engines/object/TrestleObjectWriter.java
@@ -405,6 +405,8 @@ public class TrestleObjectWriter implements ITrestleObjectWriter {
             }
         }
 
+        // Write any related_to relationships
+
 //        Invalidate the cache
         final TrestleIRI individualIRI = IRIBuilder.encodeIRI(V1, this.reasonerPrefix, owlNamedIndividual.toStringID(), null,
                 parseTemporalToOntologyDateTime(factTemporal.getIdTemporal(), ZoneOffset.UTC),

--- a/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/parser/ClassParser.java
+++ b/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/parser/ClassParser.java
@@ -765,6 +765,11 @@ public class ClassParser implements IClassParser {
 
     }
 
+    @Override
+    public boolean isFactRelated(Class<?> clazz, String factName) {
+        return false;
+    }
+
     static Optional<Object> accessMethodValue(Method classMethod, Object inputObject) {
         @Nullable Object castReturn = null;
         try {

--- a/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/parser/IClassParser.java
+++ b/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/parser/IClassParser.java
@@ -118,6 +118,15 @@ public interface IClassParser {
     Optional<IRI> getFactIRI(Class<?> clazz, String factName);
 
     /**
+     * Determines whether or not the given fact is related to other datasets in the reasoner
+     *
+     * @param clazz    - {@link Class} to parse
+     * @param factName - {@link String} of fact name to determine if it's related other other datasets
+     * @return - {@code true} fact is related to other datasets. {@link false} fact is not related to other datasets.
+     */
+    boolean isFactRelated(Class<?> clazz, String factName);
+
+    /**
      * Get the SRID projection of the class
      * If the class doesn't have a spatial projection, will return 0
      *

--- a/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/TestClasses.java
+++ b/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/TestClasses.java
@@ -671,4 +671,40 @@ public class TestClasses {
             return Objects.hash(startTemporal, objectid, geom);
         }
     }
+
+    @DatasetClass(name = "County_Related")
+    public static class CountyRelated {
+        @IndividualIdentifier
+        public final String id;
+        private final LocalDate startTemporal;
+        private final int adm0_code;
+        private final String name;
+        private final int population;
+
+        public CountyRelated(String id, LocalDate startTemporal, int adm0_code, String name, int population) {
+            this.id = id;
+            this.startTemporal = startTemporal;
+            this.adm0_code = adm0_code;
+            this.name = name;
+            this.population = population;
+        }
+
+        @StartTemporal
+        public LocalDate getStartTemporal() {
+            return startTemporal;
+        }
+
+        @Related
+        public int getAdm0_code() {
+            return adm0_code;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getPopulation() {
+            return population;
+        }
+    }
 }

--- a/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/TestClasses.java
+++ b/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/TestClasses.java
@@ -707,4 +707,37 @@ public class TestClasses {
             return population;
         }
     }
+
+    @DatasetClass(name = "GAUL_JTS_Test")
+    public static class JTSExtended implements Serializable {
+
+        private static final long serialVersionUID = 42L;
+
+        private final Integer adm0_code;
+        private final Geometry geom;
+        private LocalDate date;
+        public final int population;
+
+        public JTSExtended(Integer adm0_code, Geometry geom, LocalDate date, int population) {
+            this.adm0_code = adm0_code;
+            this.geom = geom;
+            this.date = date;
+            this.population = population;
+        }
+
+        @IndividualIdentifier
+        public Integer getAdm0_code() {
+            return this.adm0_code;
+        }
+
+        @Spatial(projection = 4269)
+        public Geometry getGeom() {
+            return this.geom;
+        }
+
+        @DefaultTemporal(name = "date", type = TemporalType.INTERVAL, duration = 1, unit = ChronoUnit.YEARS)
+        public LocalDate getDate() {
+            return this.date;
+        }
+    }
 }

--- a/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/TrestleAPITest.java
+++ b/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/TrestleAPITest.java
@@ -11,12 +11,12 @@ import com.nickrobison.trestle.types.TrestleRelation;
 import com.nickrobison.trestle.types.events.TrestleEvent;
 import com.nickrobison.trestle.types.events.TrestleEventType;
 import com.nickrobison.trestle.types.relations.ObjectRelation;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 
@@ -236,6 +236,26 @@ public class TrestleAPITest extends AbstractReasonerTest {
         reasoner.getMetricsEngine().exportData(new File("./target/api-test-gaul-loader-metrics.csv"));
     }
 
+    @Test
+    void testContributesTo() throws TrestleClassException, MissingOntologyEntity {
+        final OffsetDateTime start = LocalDate.of(1990, 1, 1).atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
+        final OffsetDateTime end = LocalDate.of(2000, 1, 1).atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
+        final TestClasses.OffsetDateTimeTest timeTest = new TestClasses.OffsetDateTimeTest(12345, start, end);
+        final TestClasses.CountyRelated related = new TestClasses.CountyRelated("Test Related", LocalDate.of(1990, 5, 14), 12345, "Related Object", 1000);
+
+        // Write the two objects
+        reasoner.writeTrestleObject(timeTest);
+        reasoner.writeTrestleObject(related);
+
+        // Read back the facts
+        final List<Object> populationValues = reasoner.getFactValues(TestClasses.OffsetDateTimeTest.class, "12345", "population", LocalDate.of(1999, 1, 11), null, null);
+        assertAll(() -> assertFalse(populationValues.isEmpty(), "Should have fact values"),
+                () -> assertEquals(1000, populationValues.get(0), "Should have correct population value"));
+
+        // Related should NOT have root object facts
+
+    }
+
     @Override
     protected String getTestName() {
         return "api_test";
@@ -250,6 +270,7 @@ public class TrestleAPITest extends AbstractReasonerTest {
                 TestClasses.GeotoolsPolygonTest.class,
                 TestClasses.OffsetDateTimeTest.class,
                 TestClasses.MultiLangTest.class,
-                TestClasses.FactVersionTest.class);
+                TestClasses.FactVersionTest.class,
+                TestClasses.CountyRelated.class);
     }
 }

--- a/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/parser/TrestleParserTest.java
+++ b/trestle-reasoner/src/test/java/com/nickrobison/trestle/reasoner/parser/TrestleParserTest.java
@@ -1,10 +1,7 @@
 package com.nickrobison.trestle.reasoner.parser;
 
 import com.nickrobison.trestle.reasoner.TestClasses;
-import com.nickrobison.trestle.reasoner.annotations.DatasetClass;
-import com.nickrobison.trestle.reasoner.annotations.Ignore;
-import com.nickrobison.trestle.reasoner.annotations.IndividualIdentifier;
-import com.nickrobison.trestle.reasoner.annotations.Spatial;
+import com.nickrobison.trestle.reasoner.annotations.*;
 import com.nickrobison.trestle.reasoner.annotations.temporal.DefaultTemporal;
 import com.nickrobison.trestle.reasoner.exceptions.TrestleClassException;
 import com.nickrobison.trestle.reasoner.parser.clojure.ClojureProvider;
@@ -223,6 +220,9 @@ public class TrestleParserTest {
         assertEquals(OWL2Datatype.XSD_INT, adm0_code.get().getObject().getDatatype().getBuiltInDatatype(), "Should have integer datatype");
         assertEquals(testMethod.getAdm0_code1(), adm0_code.get().getObject().parseInteger(), "Invalid ADM0_Code");
         assertEquals("<http://www.opengis.net/def/crs/OGC/1.3/CRS84> " + testMethod.test_name, asWKT.get().getObject().getLiteral(), "Invalid Spatial");
+
+        // Check for related fields
+        assertTrue(this.cp.isFactRelated(ExpandedGAULTests.class, "adm0_code"), "Should be related");
     }
 
     @Test
@@ -233,7 +233,7 @@ public class TrestleParserTest {
         assertAll(() -> assertTrue(facts.isPresent(), "Should have facts"),
                 () -> assertEquals(7, facts.get().size(), "Should have lots of facts"));
 
-////        Try to match on a multilang lang fact
+//        Try to match on a multilang lang fact
         final IRI iri = IRI.create(TRESTLE_PREFIX, "testString");
         final String classMember = cp.matchWithClassMember(TestClasses.MultiLangTest.class, iri.getShortForm(), "en-GB");
         assertEquals("englishGBString", classMember, "Should match with en-GB method");
@@ -378,6 +378,7 @@ public class TrestleParserTest {
     @DatasetClass(name = "GAUL_Test")
     public static class ExpandedGAULTests {
 
+        @Related
         public int adm0_code;
         @IndividualIdentifier
         public String adm0_name;


### PR DESCRIPTION
This PR adds the ability to relate two classes in such a way that the facts of one object are associated to the second object.

This is accomplished through the _contributes_to_ relationship, provided by the ontology, and the new `@Related` annotation.

There are a couple of caveats though. We don't support ad-hoc querying of facts for an object, so we always need a class definition that contains every possible fact. Which is an annoying limitation for now.

Also, annotations are not inherited, so you can't just subclass a definition and extend it.