### PR TITLE
TRESTLE-730: Migrate object writing to single thread

### DIFF
--- a/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/TrestleReasonerImpl.java
+++ b/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/TrestleReasonerImpl.java
@@ -337,7 +337,6 @@ public class TrestleReasonerImpl implements TrestleReasoner {
     @Override
     public void addFactToTrestleObject(Class<?> clazz, String individual, String factName, Object value, Temporal validFrom, @Nullable Temporal validTo, @Nullable Temporal databaseFrom) {
         this.objectWriter.addFactToTrestleObject(clazz, individual, factName, value, validFrom, validTo, databaseFrom);
-//        addFactToTrestleObjectImpl(clazz, individual, factName, value, null, validFrom, validTo, databaseFrom);
     }
 
 


### PR DESCRIPTION
Remove the complex thread poll handling from the object write path.

This is especially nice because it means we don't have destructive operations spread across multiple threads. One could imagine drastically simplified transaction handling as a result of this.