### PR TITLE
TRESTLE-735: Address failing ontology imports

### DIFF
--- a/trestle-ontology/pom.xml
+++ b/trestle-ontology/pom.xml
@@ -47,6 +47,11 @@
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-apibinding</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.jsonld-java.jsonld-java</groupId>
+            <artifactId>jsonld-java</artifactId>
+            <version>0.13.0</version>
+        </dependency>
         <!--Jena dependencies-->
         <dependency>
             <groupId>org.apache.jena</groupId>

--- a/trestle-server/src/main/resources/reference.conf
+++ b/trestle-server/src/main/resources/reference.conf
@@ -1,7 +1,6 @@
 trestle {
   ontology {
     imports {
-      importsDirectory: "/Users/nrobison/Developer/git/dissertation/trestle/trestle-ontology/src/main/resources/ontology/imports"
       importsIRIMappings: [
         {"iri": "http://purl.org/dc/elements/1.1/", "file": "dcelements.rdf"},
         {"iri": "http://www.opengis.net/ont/geosparql", "file": "geosparql.owl"},


### PR DESCRIPTION
Addressed an issue where Dublin Core was returning incorrect data and causing startup to fail.

There are a number of issues going on here, but the simplest is to simply fix the import path so we pull from our cached resources, which is a nicer option anyways.