### PR TITLE
[Chore] Switch to Artifactory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,8 @@ variables:
 resources:
   containers:
     - container: graphdb
-      endpoint: dockerHub
-      image: nickrobison/graphdb:8.2.0-free
+      endpoint: Artifactory (Docker)
+      image: trestle-docker-local.jfrog.io/graphdb:8.2.0-free
       ports:
         - 7200:7200
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,7 @@ stages:
             displayName: Login for Private Docker Images
             inputs:
               command: login
-              containerRegistry: dockerHub
+              containerRegistry: Artifactory (Docker)
           - task: Maven@3
             displayName: Build Docker image
             inputs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   graphdb:
-    image: nickrobison/graphdb:8.2.0-free
+    image: trestle-docker-local.jfrog.io/graphdb:8.2.0-free
     ports:
       - "7200:7200"
 


### PR DESCRIPTION
Switch our private Docker repo from Docker to our new [Artifactory](https://trestle.jfrog.io/) instance.

Pretty simple switch, eventually we'll move some of our JARs as well.