### PR TITLE
TRESTLE-449: Initial bump to Java 11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,16 +109,27 @@ stages:
               organization: 'nickrobison-github'
               scannerMode: 'Other'
           - task: Gradle@2
+            displayName: Run tests
             inputs:
               gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '1.11'
               tasks: 'build jacocoTestReport'
-              sonarQubeRunAnalysis: true
-              sqGradlePluginVersionChoice: 'build'
               jdkArchitectureOption: 'x64'
               publishJUnitResults: true
               testResultsFiles: '**/test-results/test/TEST-*.xml'
+          - task: Gradle@2
+              displayName: Run sonar
+              inputs:
+                gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+                javaHomeOption: 'JDKVersion'
+                jdkVersionOption: '1.11'
+                tasks: 'assemble'
+                sonarQubeRunAnalysis: true
+                sqGradlePluginVersionChoice: 'build'
+                jdkArchitectureOption: 'x64'
+                publishJUnitResults: false
+                testResultsFiles: '**/test-results/test/TEST-*.xml'
 #          - task: Maven@3
 #            inputs:
 #              mavenPomFile: 'pom.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,17 +119,17 @@ stages:
               publishJUnitResults: true
               testResultsFiles: '**/test-results/test/TEST-*.xml'
           - task: Gradle@2
-              displayName: Run sonar
-              inputs:
-                gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-                javaHomeOption: 'JDKVersion'
-                jdkVersionOption: '1.11'
-                tasks: 'assemble'
-                sonarQubeRunAnalysis: true
-                sqGradlePluginVersionChoice: 'build'
-                jdkArchitectureOption: 'x64'
-                publishJUnitResults: false
-                testResultsFiles: '**/test-results/test/TEST-*.xml'
+            displayName: Run sonar
+            inputs:
+              gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: '1.11'
+              tasks: 'assemble'
+              sonarQubeRunAnalysis: true
+              sqGradlePluginVersionChoice: 'build'
+              jdkArchitectureOption: 'x64'
+              publishJUnitResults: false
+              testResultsFiles: '**/test-results/test/TEST-*.xml'
 #          - task: Maven@3
 #            inputs:
 #              mavenPomFile: 'pom.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,26 +109,15 @@ stages:
               organization: 'nickrobison-github'
               scannerMode: 'Other'
           - task: Gradle@2
-            displayName: Run tests
             inputs:
               gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '1.11'
               tasks: 'build jacocoTestReport'
-              jdkArchitectureOption: 'x64'
-              publishJUnitResults: true
-              testResultsFiles: '**/test-results/test/TEST-*.xml'
-          - task: Gradle@2
-            displayName: Run sonar
-            inputs:
-              gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              javaHomeOption: 'JDKVersion'
-              jdkVersionOption: '1.11'
-              tasks: 'assemble'
               sonarQubeRunAnalysis: true
               sqGradlePluginVersionChoice: 'build'
               jdkArchitectureOption: 'x64'
-              publishJUnitResults: false
+              publishJUnitResults: true
               testResultsFiles: '**/test-results/test/TEST-*.xml'
 #          - task: Maven@3
 #            inputs:

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ ext {
 }
 
 allprojects {
+    group = "com.nickrobison.trestle"
+    version = "0.9.2-SNAPSHOT"
     repositories {
         // This needs to go first, in order to get the jai core jars, which jcenter doesn't have.
         maven { url "https://repo.osgeo.org/repository/release/" }
@@ -41,9 +43,6 @@ allprojects {
 }
 
 subprojects {
-
-    group = "com.nickrobison.trestle"
-    version = "0.9.2-SNAPSHOT"
     apply plugin: 'java-library'
     apply plugin: 'jacoco'
     apply plugin: "io.spring.dependency-management"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 plugins {
     id "java-library"
     id "jacoco"
-    id 'org.sonarqube' version '2.8' apply false
+    id 'org.sonarqube' version '3.0'
     id "dev.clojurephant.clojure" version "0.5.0" apply false
     id 'com.google.cloud.tools.jib' version '2.1.0' apply false
     id "io.spring.dependency-management" version "1.0.6.RELEASE" apply false
@@ -47,7 +47,6 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'jacoco'
     apply plugin: "io.spring.dependency-management"
-    apply plugin: "org.sonarqube"
 
     dependencyManagement {
         imports {

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ subprojects {
         testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitJupiterVersion
     }
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         withJavadocJar()
         withSourcesJar()
     }

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,4 +1,4 @@
 extraction:
   java:
     index:
-      java_version: "1.8"
+      java_version: "11"


### PR DESCRIPTION
Upgrade base Java level to 11.

This changes the default source/bytecode levels and updates the tooling as required.

Also fixes an issue with the project group/name not being set correctly. Sonar analysis is now working and everything.