### PR TITLE
TRESTLE-769: Write explicit fact relationships

### DIFF
--- a/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/engines/object/TrestleObjectWriter.java
+++ b/trestle-reasoner/src/main/java/com/nickrobison/trestle/reasoner/engines/object/TrestleObjectWriter.java
@@ -569,7 +569,7 @@ public class TrestleObjectWriter implements ITrestleObjectWriter {
                                             //                Write the valid validTemporal
                                             return writeTemporal(validTemporal, propertyIndividual)
                                                     //                Write the relation back to the root individual
-                                                    .andThen(Completable.defer(() -> ontology.writeIndividualObjectProperty(propertyIndividual, factOfIRI, rootIndividual)));
+                                                    .andThen(Completable.defer(() -> ontology.writeIndividualObjectProperty(rootIndividual, hasFactIRI, propertyIndividual)));
                                         }))
                                         .andThen(Completable.defer(() -> {
                                             //                Write the database time


### PR DESCRIPTION
Rather than writing a `factOf` relationships, which requires inferring the inverse `hasFact` (which is what we actually want), we should just be explicit about about we need and let the reasoner infer the `factOf`.