### PR TITLE
[Hotfix] Remove JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ allprojects {
     repositories {
         // This needs to go first, in order to get the jai core jars, which jcenter doesn't have.
         maven { url "https://repo.osgeo.org/repository/release/" }
-        jcenter()
         mavenCentral()
         maven { url "https://clojars.org/repo" }
         maven { url "https://jitpack.io" }


### PR DESCRIPTION
Remove JCenter from Gradle files

JCenter is gone, so we shouldn't pull from it anymore.