### PR TITLE
[Chore] Upgrade to Gradle 7.3.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/trestle-integrations/build.gradle
+++ b/trestle-integrations/build.gradle
@@ -52,10 +52,10 @@ dependencies {
     implementation group: 'org.locationtech.jts', name: 'jts-core'
     implementation group: 'com.esri.geometry', name: 'esri-geometry-api'
     implementation group: 'org.apache.hadoop', name: 'hadoop-client', version: hadoopVersion
-    testCompile(group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion) {
+    testImplementation(group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion) {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
-    testCompile group: 'org.apache.hadoop', name: 'hadoop-auth', version: hadoopVersion
+    testImplementation group: 'org.apache.hadoop', name: 'hadoop-auth', version: hadoopVersion
 
 
     implementation group: "org.geotools", name: "gt-shapefile", version: geotoolsVersion


### PR DESCRIPTION
Removed deprecated `testCompile` scope in `test-integrations`